### PR TITLE
Implement command-local battlefield awareness

### DIFF
--- a/Battleground2D_Architecture.md
+++ b/Battleground2D_Architecture.md
@@ -1,0 +1,266 @@
+# Battleground2D --- Architecture & Vision
+
+> Living architecture document. Update this whenever a major
+> architectural or gameplay decision is made.
+
+------------------------------------------------------------------------
+
+# Vision
+
+Battleground2D is a **large-scale cinematic 2D battle simulator**
+focused on commanding from within the battle instead of acting as an
+all-seeing RTS player.
+
+The goal is to create battles that feel **epic, chaotic, tactical, and
+believable**, where the player experiences the confusion and momentum of
+historical warfare while still influencing its outcome through
+leadership.
+
+## Inspirational References
+
+### The Battle of Gaugamela (331 BC)
+
+-   Massive armies fighting across a wide battlefield.
+-   Command hierarchy and coordinated maneuvers.
+-   Reserves, flanking, breakthroughs, and battlefield adaptation.
+-   Leadership determines victory more than individual combat.
+
+### *Alexander* (2004)
+
+-   Cinematic scale.
+-   Alexander personally leading decisive cavalry charges.
+-   Elite guards protecting commanders while allowing them to lead from
+    the front.
+-   Battles that evolve instead of remaining static.
+
+### Battle of the Bastards (*Game of Thrones*)
+
+-   Dense formations collapsing into chaos.
+-   Dynamic front lines.
+-   Units becoming surrounded.
+-   Local confusion where no one understands the entire battlefield.
+-   The player should occasionally feel overwhelmed while still finding
+    opportunities to influence the fight.
+
+------------------------------------------------------------------------
+
+## Long-Term Vision
+
+The ultimate goal is to simulate **truly massive battles** while
+maintaining believable tactics and performance.
+
+The battlefield should support:
+
+-   Thousands to eventually hundreds of thousands of units.
+-   Multiple commanders operating independently.
+-   Battles that continue evolving even without player input.
+-   Emergent stories created by interacting systems rather than scripted
+    events.
+-   Cinematic moments that naturally arise from gameplay.
+
+The player should feel like they are participating in history rather
+than watching it.
+
+------------------------------------------------------------------------
+
+# Core Design Pillars
+
+-   Dynamic battles that naturally evolve.
+-   Cinematic presentation through gameplay, not scripted sequences.
+-   Local battlefield awareness instead of omniscience.
+-   Formations are the foundation of tactics.
+-   Simple systems combining into emergent behavior.
+-   Performance-first ECS architecture.
+-   Historical-inspired command hierarchy.
+
+------------------------------------------------------------------------
+
+# Design Philosophy
+
+## Gameplay
+
+-   Information is imperfect.
+-   Decisions should have consequences.
+-   Formations matter more than individual units.
+-   Battles should remain interesting without scripted events.
+-   Systems should create emergent gameplay.
+
+## Programming
+
+Follow Pragmatic Programmer principles:
+
+-   Simple over clever.
+-   Small systems.
+-   Refactor continuously.
+-   Eliminate duplication.
+-   Build for change.
+
+------------------------------------------------------------------------
+
+# ECS Standards
+
+## Single Writer Rule
+
+Every component has exactly one owner.
+
+Examples:
+
+-   CombatState → Combat State Machine
+-   MoveGoal → MovementGoalResolver
+-   SliceState → SliceGrid System
+-   Health → Damage Pipeline
+
+## Intent Pipeline
+
+Player / AI ↓ Orders ↓ Order Processing ↓ Intents ↓ Resolvers ↓ Gameplay
+Systems
+
+Gameplay never directly controls low-level systems.
+
+## System Responsibilities
+
+Each system should answer one question:
+
+> "What is my single responsibility?"
+
+If the answer contains "and", split the system.
+
+------------------------------------------------------------------------
+
+# AI Hierarchy
+
+General ↓ Command ↓ Captain ↓ Formation ↓ Unit
+
+General = strategy
+
+Command = battlefield decisions
+
+Captain = local awareness & reports
+
+Formation = tactical execution
+
+Unit = movement, combat, animation
+
+------------------------------------------------------------------------
+
+# Battlefield Awareness
+
+Information intentionally flows upward.
+
+Slice State ↓ FormationCaptainReport ↓ CommandAwareness ↓ AI Decision
+Factory ↓ Orders
+
+Neither the AI nor the player should possess perfect battlefield
+knowledge.
+
+Future: - Physical captains - Messenger units - Delayed communication
+
+------------------------------------------------------------------------
+
+# Combat Pipeline
+
+Targeting ↓ Combat Intent ↓ Combat State ↓ Attack Resolution ↓ Damage ↓
+Death ↓ Animation
+
+------------------------------------------------------------------------
+
+# Movement Pipeline
+
+Orders ↓ Order Intents ↓ MoveGoalResolver ↓ MoveGoal ↓ MovementSystem
+
+MovementSystem is the only system that moves entities.
+
+------------------------------------------------------------------------
+
+# Formation Philosophy
+
+Formations---not individual units---are the primary tactical objects.
+
+Responsibilities:
+
+-   Cohesion
+-   Positioning
+-   Advance
+-   Charge
+-   Defend
+-   Break off
+-   React to battlefield pressure
+
+------------------------------------------------------------------------
+
+# Slice System
+
+Slices represent **objective simulation telemetry**. They contain the
+battlefield evidence from which local knowledge is produced; neither AI
+decision systems nor player-facing UI may consume the global slice map
+directly.
+
+Slices communicate:
+
+-   Control
+-   Pressure
+-   Momentum
+-   Stability
+
+Their purpose is to feed observation and reporting systems, not directly
+control gameplay.
+
+## Command Awareness
+
+Each Command owns its own imperfect battlefield knowledge. The physical
+commander supplies the center of a configurable observation circle. Slices
+and formation bounds intersecting that circle are observed in real time.
+
+The knowledge pipeline is:
+
+SliceState (objective telemetry) → direct observation / captain reports →
+CommandKnownSlice and CommandKnownFormation memory → CommandAwareness → AI
+planning and player information.
+
+Observed information is refreshed immediately. Information outside the
+observation circle remains frozen, loses confidence, and expires after its
+configured memory duration. Owning a formation does not grant live knowledge
+of that formation.
+
+The current player test radius is 14 world units, chosen to approximate the
+player's zoomed-out Tab camera view. This remains a tuning value rather than an
+architectural constant.
+
+`CommandAwarenessSystem` is the only writer of Command-owned knowledge and its
+aggregate awareness summary. Debug and UI systems are read-only consumers.
+
+------------------------------------------------------------------------
+
+# Current Priorities
+
+1.  Validate Command-local observation and stale memory in ECS_Scene.
+2.  Add explicit captain-report delivery rules beyond direct observation.
+3.  Drive AI decisions from CommandAwareness.
+4.  Continue Orders-as-Intent pipeline.
+5.  Expand formation behaviors.
+6.  Elite Guards.
+7.  Morale and battle flow.
+
+------------------------------------------------------------------------
+
+# Coding Checklist
+
+Before adding a feature ask:
+
+-   Does this violate single-writer?
+-   Does this belong in an existing pipeline?
+-   Can this become data instead of logic?
+-   Does it increase coupling?
+-   Is it independently testable?
+
+------------------------------------------------------------------------
+
+# Definition of Done
+
+A feature is complete when:
+
+-   Ownership is clear.
+-   Responsibilities are isolated.
+-   Logic is reusable.
+-   Performance is acceptable.
+-   Gameplay is more interesting.

--- a/Battleground2D_Conversation_Handoff.md
+++ b/Battleground2D_Conversation_Handoff.md
@@ -1,0 +1,1002 @@
+# Battleground2D — Complete Conversation Handoff
+
+> This document consolidates the recent Battleground2D architecture discussions so the work can continue in Codex without relying on the original chat transcript.
+>
+> `Battleground2D_Architecture.md` and `Roadmap.md` remain the project's source of truth. When this handoff records a newer decision that conflicts with those files, the conflict is called out explicitly and the living documents should be updated.
+
+---
+
+## 1. Project role and working agreement
+
+Battleground2D is a Unity DOTS, top-down 2D, large-scale battle simulation. The assistant/Codex should act as a senior gameplay and engine architect.
+
+The assistant should:
+
+- Challenge architectural decisions when appropriate instead of simply agreeing.
+- Favor clean ECS ownership, maintainability, and long-term scalability over quick implementation.
+- Apply performance-first ECS design.
+- Enforce the single-writer rule.
+- Follow Pragmatic Programmer principles: simple over clever, small systems, eliminate duplication, refactor continuously, and build for change.
+- Treat `Battleground2D_Architecture.md` as a living document and update it whenever an important architectural or gameplay decision is accepted.
+- Treat `Roadmap.md` as the living implementation checklist.
+- Clearly distinguish implemented code, discussed design, and future ideas.
+
+---
+
+## 2. Game vision
+
+The goal is a massive-scale, cinematic battle simulator in which the player commands from inside the battle rather than behaving like an omniscient RTS camera.
+
+The battle should feel:
+
+- Epic and cinematic.
+- Chaotic but understandable locally.
+- Tactical and believable.
+- Dynamic rather than static.
+- Emergent rather than heavily scripted.
+- Capable of continuing and evolving without player input.
+
+The intended hierarchy is:
+
+```text
+General
+  ↓
+Command
+  ↓
+Captain
+  ↓
+Formation
+  ↓
+Unit
+```
+
+Responsibilities:
+
+- **General:** overall strategy.
+- **Command:** battlefield-level interpretation and decisions.
+- **Captain:** local observation and reports.
+- **Formation:** tactical execution.
+- **Unit:** movement, combat, and animation.
+
+Inspirations:
+
+- **Battle of Gaugamela:** enormous scale, coordinated commands, reserves, flanks, breakthroughs, adaptation, and leadership determining the battle.
+- **Alexander (2004):** Alexander personally leading decisive attacks, commanders participating physically, elite guards following and protecting commanders, and large cinematic maneuvers.
+- **Battle of the Bastards:** formations collapsing into dense chaos, soldiers becoming surrounded, a shifting frontline, and local confusion in which nobody understands the whole battlefield.
+
+Long-term scale is thousands of units, eventually reaching tens or hundreds of thousands if technically feasible. Earlier performance testing was stable around 6,000 units at roughly 30 FPS on low-end hardware, while 20,000 units had previously become unusably slow. The aspirational scale has been discussed as 100,000+ and potentially around 240,000, but architecture and profiling must decide what is practical.
+
+The central gameplay idea can be summarized as **dynamic battles**: simple interacting systems should create changing pressure, collapses, counterattacks, breakthroughs, and cinematic stories.
+
+---
+
+## 3. Architectural principles already established
+
+### 3.1 Single-writer ECS
+
+Every authoritative component must have one owner/writer.
+
+Examples:
+
+| Component/data | Authoritative writer |
+|---|---|
+| `CombatState` | Combat state machine |
+| `Health` and death state | Damage/death pipeline |
+| `Translation` / physical position | Movement or physics pipeline |
+| `MoveGoal` | `MovementGoalResolverSystem` |
+| `SliceState` | Slice pipeline / `SliceGridSystem` |
+| Formation structural data | Formation pipeline |
+| `CommandAwareness` | `CommandAwarenessSystem` |
+
+Other systems communicate by writing intents, requests, events, or source data. They must not bypass the owning resolver.
+
+### 3.2 Intent pipeline
+
+The desired general flow is:
+
+```text
+Player / AI
+    ↓
+Orders
+    ↓
+Order processing
+    ↓
+Intents
+    ↓
+Resolvers
+    ↓
+Movement / combat / gameplay systems
+```
+
+High-level gameplay systems should state what they want, not directly manipulate low-level execution state.
+
+### 3.3 Small responsibilities
+
+Each system should answer one main question. If the responsibility can naturally be described with “and,” it should be examined for a split.
+
+### 3.4 Formations are the tactical objects
+
+Formations—not individual units—are the primary objects for command-level tactics. A formation owns or coordinates:
+
+- Cohesion.
+- Shape and slots.
+- Positioning.
+- Advance.
+- Charge.
+- Defend/hold.
+- Break-off or withdrawal.
+- Reaction to local pressure.
+
+Units execute formation and combat behavior but should not independently become command-level thinkers.
+
+---
+
+## 4. Existing major systems and current state
+
+### 4.1 Combat — complete/stable foundation
+
+The combat work already includes:
+
+- `CombatState` replacing many combat booleans.
+- States such as Idle, Seeking, Attacking, Defending, Blocking, TakingDamage, and Dying.
+- Player and AI block behavior.
+- Directional attack/block corrections.
+- Attack resolution.
+- Damage application.
+- Death handling, animation, sprite ordering, and entity deletion.
+- View direction separated from movement direction.
+- AI and player animation-direction fixes.
+
+The combat pipeline is conceptually:
+
+```text
+Targeting
+  ↓
+Combat intent
+  ↓
+Combat state machine
+  ↓
+Attack resolution
+  ↓
+Damage
+  ↓
+Death
+  ↓
+Animation
+```
+
+A prior Defend behavior detail was that entering Defend starts a five-second cooldown/timer, while invalid or out-of-range targets can return the unit to Seeking. This should be checked against current code before relying on it.
+
+### 4.2 Formations — MVP mostly complete
+
+Implemented or substantially working:
+
+- `FormationComponent`.
+- `FormationGroupComponent`.
+- Formation group ownership of formation-level data.
+- `FormationMovementSystem`.
+- `FormationCombatSystem`.
+- Hold Position.
+- Basic Advance.
+- Straight-line formation movement.
+- Basic attack-move.
+- Formation collision/avoidance.
+- Break-off/reposition behavior.
+- Fixes for stuck units, NaNs, combat exits, and formation entry into combat.
+- Removal of pre-clash per-unit target searches.
+
+Still listed as incomplete in the current Roadmap:
+
+- Basic Charge.
+- Charge requiring a valid target.
+- Stamina/morale benefits for Charge.
+
+### 4.3 Slice/frontline system — implemented truth/telemetry foundation
+
+The battlefield is divided into `8 × 8` logical grid slices. Previously discussed grid details included an origin around `(-32, -16)` and a key scheme using a large Y multiplier such as `100000`; current code remains authoritative.
+
+Per-frame accumulation tracks values such as:
+
+- Allied strength/presence.
+- Enemy strength/presence.
+- Intensity.
+
+Persistent slice state smooths and remembers battlefield conditions:
+
+- Control.
+- Intensity.
+- Momentum.
+- Tactical state.
+
+Known tactical-state names discussed include `Empty`, `Clash`, `AllyAdvantage`, and `EnemyAdvantage`. Older roadmap language also mentions Dominated/Contested and Stable/Pressured/Collapsing/Broken; the active enum in code must be treated as authoritative.
+
+Previously discussed tuning constants included:
+
+```text
+ControlSmoothing          = 0.25
+IntensitySmoothing        = 0.25
+InactiveDecayRate         = 0.85
+PruneAfterSeconds         = 2.5
+PruneIntensityThreshold   = 0.05
+StateUpdateInterval       = 0.15
+PresenceMin               = 0.5
+ClashPresenceMin          = 5
+AdvantageControlMin       = 0.25
+MomentumThreshold         = 0.05
+```
+
+These are historical discussion values and must be verified against the current source before modification.
+
+The slice pipeline also includes smoothing, time gates/hysteresis, decay/pruning, and neighbor influence so pressure does not flicker and local collapse can influence nearby areas.
+
+---
+
+## 5. Core targeting and movement cleanup
+
+The Phase 3B-0 cleanup established distinct ownership for target references and final movement goals.
+
+### 5.1 Target ownership
+
+- `CombatTarget` stores only the target entity reference.
+- `FindTargetSystem` writes/assigns `CombatTarget`.
+- `TargetValidationSystem` validates or clears `CombatTarget`.
+- `TargetReevaluationSystem` may change `CombatTarget` without producing movement side effects.
+- The old shared `HasTarget` component was removed from order, formation combat, targeting, and movement systems and then deleted.
+
+### 5.2 Movement sources and resolution
+
+Movement inputs/sources include:
+
+- `FormationSlotGoal`.
+- `OrderMoveIntent`.
+- A target position derived from `CombatTarget` when current behavior allows pursuit or charge.
+- Possible future `PursuitIntent` and `ChargeIntent`.
+
+The final movement pipeline is:
+
+```text
+FormationSlotGoal ─┐
+OrderMoveIntent ───┼─→ MovementGoalResolverSystem → MoveGoal → MovementSystem
+CombatTarget ──────┘
+```
+
+Rules:
+
+- `MovementGoalResolverSystem` is the only writer of `MoveGoal`.
+- Movement reads only `MoveGoal`.
+- Arrive/stop behavior includes a dead zone, avoids overshoot, and avoids jitter near the destination.
+- `MovementLock` or equivalent lets combat/hold behavior stop motion without other systems directly erasing or overwriting movement goals.
+- Combat writes combat/lock state, not `MoveGoal` directly.
+
+### 5.3 Remaining discrepancy
+
+The current `Roadmap.md` still marks removal of cached `TargetPosition` from the targeting flow as incomplete, even though a later conversation summary described Phase 3B-0 as complete. Until the code proves otherwise, this item remains **not confirmed complete**.
+
+---
+
+## 6. Order-system cleanup discussion
+
+The important distinction was:
+
+```text
+Order = what the commander/formation was told to accomplish
+Target acquisition = an internal operation needed to accomplish it
+Behavior = how the formation currently carries it out
+```
+
+### 6.1 `Attack` versus `FindTarget`
+
+- `Attack` is the real order.
+- `FindTarget` is an internal targeting operation, not a player-facing or commander-level order.
+- Issuing Attack leaves the active order as Attack.
+- If a unit/formation executing Attack lacks a valid `CombatTarget`, `FindTargetSystem` locates one.
+- Target acquisition must never silently replace the active Attack order with a FindTarget order.
+- Combat and movement systems react to the acquired `CombatTarget` according to current behavior.
+
+### 6.2 Cleaned factory direction
+
+The desired `OrderFactory` surface was:
+
+```csharp
+CreateIdleOrder()
+CreateMoveOrder(...)
+CreateAttackOrder()
+CreateDefendOrder(...)
+CreateMarchOrder()
+CreateChargeOrder()
+CreateMoveDirectionalOrder(...)
+```
+
+The exact current signatures must be taken from the repository.
+
+### 6.3 Input mapping discussed
+
+The cleaned test/input mapping was approximately:
+
+| Index | Resulting order |
+|---:|---|
+| 0 | Charge |
+| 1 | March |
+| 2 | MoveDirectionalRange |
+| 3 | Defend |
+| 4 | MoveTo |
+| 5 | Idle |
+| 6 | Attack |
+| 7 | MoveTo/custom movement |
+| 8 | Attack/custom attack |
+
+This mapping was described as approximate because the source method and key bindings may have changed.
+
+### 6.4 Status
+
+The conceptual cleanup is accepted, but the current code should be inspected before claiming every old `FindTarget` order path or legacy factory method is gone. Orders-as-Intent remains scheduled for Phase 3D and should not be expanded prematurely while the awareness boundary is being established.
+
+---
+
+## 7. Formation Captain reporting and local tactical state
+
+`FormationCaptainReport` has been created as an MVP informational layer. The captain does not need to be a physical character yet.
+
+Its role is:
+
+- Be tied to a formation/formation group.
+- Observe the formation’s local area of responsibility.
+- Summarize local slice evidence.
+- Report upward to an owned Command.
+- Avoid making command decisions itself.
+
+A reporting system was discussed as scanning each formation group, using its formation position/bounds or area-of-responsibility AABB, gathering relevant slices, calculating a local summary, and writing only that formation’s report. Commander knowledge filtering belongs to the later Command awareness layer, not the captain report producer.
+
+### 7.1 Captain states
+
+States discussed include:
+
+- `Idle`
+- `Holding`
+- `Winning`
+- `SlightEdge`
+- `Pressured`
+- `Collapsing`
+- `Broken`
+- `Unknown`
+
+An early control-based classification used thresholds approximately like:
+
+```text
+control >=  0.75 → Holding
+control >=  0.35 → Winning
+control >=  0.10 → SlightEdge
+control >  -0.10 → Holding
+control >  -0.35 → Pressured
+control >  -0.75 → Collapsing
+otherwise         → Unknown
+```
+
+Feedback was that Collapsing occurred too early and a fight could begin as Unknown. The revised behavior must account for intensity and presence, not only control:
+
+- If there is no meaningful intensity/presence, use `Idle`.
+- Do not declare Collapsing too early.
+- Avoid `Unknown` merely because a clash has just started.
+- `Broken` should represent a genuinely failed formation, not just a locally negative control number.
+
+The exact final thresholds are not confirmed in this handoff and should be read from current code.
+
+### 7.2 Desired report contents
+
+The report should contain enough information to preserve who observed what, where, and when. A discussed shape was:
+
+```csharp
+public struct FormationCaptainReport : IComponentData
+{
+    public Entity Command;
+    public Entity Formation;
+
+    public float2 ReportPosition;
+    public FormationCaptainState State;
+
+    public float Control;
+    public float Intensity;
+    public float Momentum;
+
+    public double ObservedTime;
+}
+```
+
+The report position should come from the formation anchor, bounds center, or another formation-level representative point—not an arbitrary individual unit.
+
+### 7.3 Future extension
+
+The current report is informational and effectively immediate once its delivery condition is satisfied. Future physical captains and messenger units should change **delivery**, not force a redesign of observation, memory, awareness, or AI consumers.
+
+---
+
+## 8. AI tactical decision factory discussion
+
+The key separation is:
+
+```text
+Order = what the formation must accomplish
+Captain state/report = what is happening locally
+Tactical decision/behavior = how it currently attempts the order
+```
+
+For example, an Attack order under pressure remains Attack; it is executed defensively. The formation should not mutate its high-level order every time local pressure changes.
+
+### 8.1 Attack MVP mapping
+
+The discussed/implemented Attack behavior mapping was:
+
+| Captain state | Tactical decision | Formation-group result |
+|---|---|---|
+| `Broken` | `Retreat` | `FormationGroupStatus.Broken` |
+| `Collapsing` | `FightingWithdrawal` | `Disengaging` |
+| `Pressured` | `DefensiveAttack` | `Engaged` |
+| Other states | `NormalAttack` | `Engaged` |
+
+### 8.2 Structure discussed or substantially implemented
+
+- `TacticalDecisionFactory`.
+- `AttackDecisionFactory`.
+- `FormationBehaviorFactory`.
+- `FormationTacticalDecision` ECS component.
+- Decision-processing system.
+- Minimal behavior-execution system.
+- `FormationBehavior` components/systems.
+- Optional formation-spawner initialization.
+
+A later commit-style summary indicated this work was substantially implemented, including:
+
+- FormationCaptain behavior-decision pipeline.
+- Order-specific tactical-decision factories.
+- Reusable formation behavior architecture.
+- Captain-state evaluation.
+- `FormationBehavior` components.
+- Alive-unit/intensity cleanup.
+- Expanded formation debugging and visualization.
+- Slice refinements.
+- Spawn/test configuration changes.
+- General ECS cleanup.
+
+However, current repository code is still the authority for exactly which types and mappings exist.
+
+### 8.3 Correct future input
+
+The tactical decision factory remains valid, but command-level AI must ultimately receive information through the imperfect-knowledge pipeline. It must not query the global slice map directly.
+
+Formation-local behavior may use its own captain/local state, while Command-level planning uses `CommandAwareness` and produces orders.
+
+---
+
+## 9. Critical architecture correction: truth versus knowledge
+
+The current `Battleground2D_Architecture.md` says:
+
+> “Slices represent local battlefield knowledge, not objective truth.”
+
+The newer accepted design separates objective simulation evidence from perceived knowledge:
+
+```text
+SliceState
+  = objective simulation telemetry / battlefield evidence
+
+FormationCaptainReport
+  = local observation of that evidence
+
+CommandKnownSlice + CommandAwareness
+  = delayed, incomplete, stale perceived knowledge
+```
+
+The complete pipeline is:
+
+```text
+SliceState (simulation truth)
+        ↓
+Direct command observation + FormationCaptainReport
+        ↓
+Delivery, ownership, range, and age filtering
+        ↓
+CommandKnownSlice memory
+        ↓
+CommandAwareness summary
+        ↓
+AI Decision Factory
+        ↓
+Orders
+        ↓
+Formation tactical behavior
+        ↓
+Units
+```
+
+Why this separation matters:
+
+- If slices themselves are “knowledge,” truth and perception become mixed.
+- Messenger delays become difficult to model.
+- Stale intelligence becomes ambiguous.
+- Missing reports and commander isolation become awkward.
+- UI may accidentally expose omniscient data.
+- AI may accidentally read live global truth.
+
+Therefore, `SliceState` should remain an objective internal simulation layer, while observation/report/delivery/memory create imperfect knowledge.
+
+**Document discrepancy:** the attached Architecture file has not yet incorporated this correction even though a previous response said it had been updated. It should be corrected during the next Architecture update.
+
+---
+
+## 10. `CommandAwareness` is generic and primarily supports AI Commands
+
+The first awareness proposal focused too much on the player. The corrected decision is:
+
+> `CommandAwareness` is a shared capability for every Command—player or AI. The AI is its primary gameplay consumer. Player debug visualization and future UI are alternate views of the same knowledge data.
+
+Rules:
+
+- The awareness system processes all Commands, not only entities with `PlayerTag`.
+- The awareness radius belongs to the physical commander/command representative, not specifically to the player.
+- Each Command has its own origin, radius, observations, reports, memory, confidence, and summary.
+- AI Commands use their own local radius and delivered reports to make decisions.
+- AI decision systems read `CommandAwareness`, never the raw global `SliceStateMap`.
+- Owning a formation grants authority to command it; ownership does **not** grant live knowledge of everything around it.
+- A distant owned formation must not turn into an RTS scouting camera.
+- The player physically sees the nearby battlefield, so the player may need less artificial visualization during ordinary play; the data still powers summaries, reports, and optional tactical UI.
+
+Generic flow:
+
+```text
+Physical commander position
+        ↓
+Slices inside direct-observation radius
+        +
+Delivered captain reports
+        +
+Stale remembered information
+        ↓
+CommandAwareness
+        ↓
+AI planning / player information
+```
+
+Only the player Command currently exists, so it will be used to build and test the generic system. It is effectively standing in as the first “AI Command” test case.
+
+---
+
+## 11. Proposed awareness data model
+
+Names and exact storage can still be adjusted to match the installed Unity Entities version, but the responsibilities should remain separate.
+
+### 11.1 Per-command configuration
+
+```csharp
+public struct CommandAwarenessConfig : IComponentData
+{
+    public float DirectObservationRadius;
+    public float ReportDeliveryRadius;
+    public float MemoryDuration;
+}
+```
+
+Starting tuning values discussed:
+
+- Direct observation radius: approximately `40` world units.
+- Report delivery radius: approximately `48` world units.
+- Memory duration: approximately `10` seconds.
+
+With `8 × 8` slices, a 40-unit radius reaches roughly five slices outward.
+
+These are starting test values, not final game balance.
+
+### 11.2 Direct observation
+
+An early player-specific name was `PlayerSliceObservation`. Because the design is now generic, a better name may be `CommandSliceObservation`.
+
+Possible transient buffer element:
+
+```csharp
+public struct CommandSliceObservation : IBufferElementData
+{
+    public int SliceKey;
+    public float Control;
+    public float Intensity;
+    public float Momentum;
+    public double ObservedTime;
+}
+```
+
+Responsibilities:
+
+- Produced from each Command’s physical position and direct-observation radius.
+- Contains only currently observed slices.
+- Is transient/source data, not long-term memory.
+- Has a single observation-system writer.
+
+### 11.3 Persistent known-slice memory
+
+```csharp
+public struct CommandKnownSlice : IBufferElementData
+{
+    public int SliceKey;
+
+    public float Control;
+    public float Intensity;
+    public float Momentum;
+
+    public double LastObservedTime;
+    public AwarenessSource Source;
+    public float Confidence;
+}
+```
+
+Possible source enum:
+
+```csharp
+public enum AwarenessSource : byte
+{
+    DirectObservation,
+    CaptainReport,
+    Memory
+}
+```
+
+This buffer represents what a specific Command currently believes about known areas. It supports AI reasoning, debugging, and future player UI.
+
+### 11.4 Command-level summary
+
+```csharp
+public struct CommandAwareness : IComponentData
+{
+    public CommandPressureState Pressure;
+
+    public float Control;
+    public float Intensity;
+    public float Momentum;
+    public float Confidence;
+
+    public int KnownSliceCount;
+    public int ReceivedReportCount;
+    public double LastUpdatedTime;
+}
+```
+
+This is the coarse summary consumed by command-level AI and decision factories.
+
+`CommandAwarenessSystem` should be the only writer of persistent `CommandKnownSlice` knowledge and the final `CommandAwareness` summary.
+
+### 11.5 Possible system separation
+
+A clean split would be:
+
+1. `CommandObservationSystem`
+   - Reads Command position/config and objective `SliceState`.
+   - Writes current direct observations only.
+
+2. `FormationCaptainReportSystem`
+   - Reads formation-local slice evidence.
+   - Writes each formation’s latest local report.
+
+3. `CommandAwarenessSystem`
+   - Determines which reports are delivered.
+   - Merges direct observations, delivered reports, and old memory.
+   - Updates confidence and age.
+   - Writes `CommandKnownSlice` and `CommandAwareness`.
+
+4. Debug/UI systems
+   - Read knowledge only.
+   - Never mutate awareness and never read global truth for player-facing information.
+
+This split preserves single-writer ownership and makes messenger delivery replaceable later.
+
+---
+
+## 12. Position, visibility, delivery, and memory rules
+
+### 12.1 Awareness origin
+
+Use the physical commander entity’s position. The abstract Command entity may own identity and state, but the physical representative provides the observation origin.
+
+The mapping between Command and physical commander must be explicit, for example through an entity reference. Do not infer the player only through a global singleton because future battles will contain multiple Commands.
+
+### 12.2 Direct observation intersection
+
+Test whether the observation circle intersects a slice’s bounds, rather than checking only the slice center. Center-only tests cause abrupt popping near boundaries.
+
+Later hysteresis could use different enter/leave distances, for example:
+
+- Enter visibility at 40 units.
+- Leave visibility at 44 units.
+
+### 12.3 Captain-report delivery MVP
+
+A captain report is delivered when:
+
+```text
+Report belongs to the Command
+AND report/formation is within communication distance of the commander
+AND report is recent enough
+```
+
+For the MVP, proximity substitutes for actual communication. A nearby captain can tell the commander what is happening in that formation’s area of responsibility, extending knowledge beyond direct personal observation.
+
+A distant owned captain may still generate a local report, but the Command does not receive fresh information until a delivery condition is met.
+
+Future replacement:
+
+```text
+MVP delivery: captain is in communication radius
+Future delivery: messenger physically reaches commander
+```
+
+The rest of `CommandAwareness` should remain unchanged.
+
+### 12.4 Merge precedence
+
+When several sources describe the same area:
+
+1. Newer direct observation.
+2. Fresh delivered captain report.
+3. Existing/stale memory.
+4. Unknown.
+
+Important nuance: source type alone should not blindly overwrite newer information. A report should not replace a newer direct observation, and an older direct observation should not replace a newer delivered report. Recency and source confidence both matter.
+
+### 12.5 Stale knowledge
+
+When a slice leaves observation and no report refreshes it:
+
+- Preserve the last known values.
+- Mark the source as memory or derive memory from age.
+- Lower confidence over time.
+- Do not continue reading/updating it from objective `SliceState`.
+- After `MemoryDuration`, remove it or mark it Unknown.
+
+This creates the desired “run the line” experience. A commander can inspect one part of the battlefield and remember what was happening, but cannot know that the situation remained unchanged after leaving.
+
+### 12.6 No global omniscient summary
+
+Older plans mention a coarse Left/Center/Right global summary. The more recent constraint is:
+
+- No exact global awareness in normal gameplay.
+- A Left/Center/Right summary, if retained before messenger systems exist, should be debug/dev-only.
+- A gameplay summary may exist later only when produced by delayed/stale reports or messenger delivery.
+- Player and AI should not use an omniscient battlefield-wide summary.
+
+---
+
+## 13. Debugging plan: use the player Command as the first AI Command
+
+Because only the player Command exists, use it to validate the generic Command awareness system.
+
+The debug view should intentionally show:
+
+1. The physical commander origin.
+2. The direct-observation radius as a debug circle.
+3. Slices currently directly observed.
+4. Areas known through delivered captain reports.
+5. Remembered/stale slices and their age/confidence.
+6. Unknown areas.
+7. The final coarse `CommandAwareness` values/state.
+
+Suggested visual distinctions:
+
+| Knowledge state | Debug treatment |
+|---|---|
+| Direct observation | Bright, accurate outline/color |
+| Captain report | Different color, icon, or marker |
+| Recent memory | Faded/desaturated |
+| Old memory | Heavily faded or `?` |
+| Unknown | Hidden or optional debug-only outline |
+
+The global game-manager debug toggle discussed elsewhere should gate `Debug.Draw`, gizmos, and debug text so visualization can be toggled during Inspector play mode.
+
+The debug rendering must be a reader only. It must not become the owner of awareness data or perform hidden perception calculations.
+
+---
+
+## 14. Future player-awareness UI
+
+The debug visualization is also a prototype for a gameplay feature: showing the player what their Command currently knows.
+
+The dependency should be:
+
+```text
+CommandAwareness / CommandKnownSlice
+        ├── AI decision systems
+        ├── Debug visualization
+        └── Player awareness UI
+```
+
+Do not convert `Debug.Draw` code directly into gameplay UI. Both debug and UI should independently read the same knowledge components.
+
+Possible gameplay UI uses:
+
+- A tactical map showing known local areas.
+- A battlefield overlay.
+- A local pressure/status strip.
+- Captain report icons or a diegetic report feed.
+- Fresh information shown brightly.
+- Older intelligence fading/desaturating.
+- Unknown regions hidden.
+- A visible distinction between personally observed information and captain-reported information.
+
+The UI must never read raw `SliceState`, because doing so would reveal objective battlefield truth and break the anti-RTS design.
+
+The player already physically sees nearby fighting, so the UI should explain knowledge and reports rather than redundantly covering the entire combat view in debug colors.
+
+---
+
+## 15. First playable validation scenario
+
+Set up three formations:
+
+1. One fighting beside the player/commander.
+2. One fighting outside direct observation but close enough for its captain report to be delivered.
+3. One fighting far from the commander and outside report-delivery range.
+
+Expected results:
+
+- Nearby slices appear as live direct observations.
+- The nearby captain expands the Command’s knowledge beyond personal observation.
+- The distant formation does not provide live Command knowledge merely because it is owned.
+- Walking away causes knowledge to become stale rather than continuing to update.
+- Confidence visibly declines with age.
+- Expired information becomes Unknown or disappears after the configured memory duration.
+- Returning to an area immediately refreshes direct observations.
+- Moving close enough to the distant captain/formation finally delivers or refreshes its information.
+- The coarse `CommandAwareness` output changes only from information the Command legitimately knows.
+
+Future AI validation:
+
+- Create an AI Command with the same components.
+- Give it a physical commander position.
+- Confirm it gets different knowledge than the player when positioned elsewhere.
+- Confirm its decision factory reacts to `CommandAwareness` after a deliberate reaction delay.
+- Confirm it does not react instantly to distant raw-slice changes.
+
+---
+
+## 16. Recommended implementation order
+
+The immediate work should establish the awareness boundary before expanding Orders-as-Intent.
+
+1. Correct the architecture language: `SliceState` is objective telemetry; reports and awareness are imperfect knowledge.
+2. Confirm the existing `FormationCaptainReport` fields and single writer.
+3. Add `CommandAwarenessConfig` to the Command prefab/spawn path.
+4. Add an explicit reference from each Command to its physical commander/awareness origin.
+5. Add a generic current-observation buffer such as `CommandSliceObservation`.
+6. Implement `CommandObservationSystem` for every Command, not just `PlayerTag`.
+7. Use circle-versus-slice-bounds intersection and draw the debug radius.
+8. Ensure captain reports contain origin, observed time, control, intensity, momentum, and state as needed.
+9. Implement MVP report-delivery filtering by ownership, proximity, and freshness.
+10. Add persistent `CommandKnownSlice` memory.
+11. Implement merge precedence and confidence decay.
+12. Aggregate legitimate known information into `CommandAwareness`.
+13. Make `CommandAwarenessSystem` the sole writer of final knowledge/summary data.
+14. Add debug visualization for direct observation, reports, memory, unknown areas, and the coarse summary.
+15. Run the three-formation playable test.
+16. Add a second AI Command and verify the system needs no redesign.
+17. Connect command-level AI decision logic to `CommandAwareness` with a reaction delay.
+18. Later connect player gameplay UI to `CommandKnownSlice`/`CommandAwareness`.
+19. Resume the Phase 3D Orders-as-Intent expansion after awareness ownership is stable.
+
+---
+
+## 17. What is implemented, discussed, and not yet confirmed
+
+### Confirmed by the current Roadmap
+
+- Combat phase tasks are complete.
+- Formation MVP is substantially complete except Charge work.
+- Persistent slice/frontline state is complete.
+- Targeting/movement ownership cleanup is mostly complete.
+- Command entity concept exists.
+- Dynamic Command label generation exists.
+- `FormationCaptainReport` exists.
+
+### Discussed or apparently substantially implemented, but must be checked in code
+
+- Tactical decision factories and formation behavior pipeline.
+- Attack decision mapping by captain state.
+- Captain-state thresholds and intensity handling.
+- Expanded captain/formation debug visualization.
+- Exact `OrderFactory` cleanup.
+- Exact removal of `FindTarget` as an order type.
+- Whether cached `TargetPosition` is fully removed.
+
+### Not implemented/unfinished according to the current Roadmap and latest discussion
+
+- Generic per-Command direct observation radius.
+- Persistent known-slice memory and staleness.
+- Report-delivery filtering.
+- Final `CommandAwareness` aggregation.
+- AI Command reaction delay.
+- AI Command using `CommandAwareness` as its only command-level battlefield input.
+- Gameplay player-awareness UI.
+- Physical captains and messenger delivery.
+- Gameplay-safe delayed/stale global summaries.
+- Phase 3D Command intents and propagation.
+- Phase 3E full battle loop.
+
+---
+
+## 18. Open implementation decisions that should be resolved from code or ADRs
+
+These items were not fully settled and should not be guessed silently:
+
+1. **Command-to-physical-commander link:** exact component/entity-reference structure.
+2. **Observation storage:** transient dynamic buffer versus temporary native collection feeding the awareness writer.
+3. **Known-slice storage:** per-Command dynamic buffer versus a centralized map keyed by `(Command, SliceKey)`; start simple unless profiling proves a problem.
+4. **Report granularity:** one formation summary versus per-slice report entries for a formation’s area of responsibility.
+5. **Report delivery distance:** commander-to-captain point distance versus commander-to-formation-bounds distance.
+6. **Confidence formula:** linear decay, stepped freshness bands, or source-dependent decay.
+7. **Memory expiration:** delete entries or retain Unknown records for UI history/debugging.
+8. **Summary weighting:** control weighted by intensity, formation strength, confidence, age, or a combination.
+9. **Pressure classification:** exact thresholds and hysteresis for Stable/Pressured/Collapsing/Broken.
+10. **Reaction delay:** fixed interval versus per-Command planner cooldown/jitter.
+11. **Captain report cadence:** every slice update, fixed interval, or only on meaningful state change.
+12. **Current Unity API constraints:** the project uses an older Entities/DOTS version, so proposed modern-looking sample types/APIs must be adapted to the repository rather than copied blindly.
+
+---
+
+## 19. Architecture constraints for all future code
+
+- Never let AI command logic read the global slice map directly.
+- Never let player UI read global objective slice truth.
+- Never equate ownership with live knowledge.
+- Never let target acquisition replace the active Attack order.
+- Never let behavior changes rewrite the strategic purpose of an order without an explicit higher-level decision.
+- Never introduce multiple writers for `MoveGoal`, `CombatState`, `SliceState`, `CommandKnownSlice`, or `CommandAwareness`.
+- Avoid per-unit work for command awareness; query Commands, formation reports, and slice windows.
+- Keep debug systems read-only.
+- Make messenger units a delivery-layer replacement, not an awareness-system rewrite.
+- Preserve stale knowledge rather than granting magical live updates.
+- Prefer formation-level aggregation and fixed/limited update cadences for performance.
+- Do not jump into the full Orders-as-Intent Phase 3D until the Command awareness input boundary is stable.
+
+---
+
+## 20. Exact point to resume
+
+The immediate next task is:
+
+```text
+Existing FormationCaptainReport
+        +
+Generic Command-local direct observation
+        ↓
+CommandAwarenessSystem
+        ↓
+CommandKnownSlice memory + CommandAwareness summary
+```
+
+The player Command is the initial test Command. Draw its awareness radius and knowledge states to validate the generic system, but do not write player-specific architecture.
+
+Before implementing, inspect the current versions of:
+
+- Command components and spawn/ownership code.
+- The physical player/commander entity reference and position component.
+- `FormationCaptainReport`.
+- `FormationCaptainReportSystem`.
+- Slice state structs and the slice-state map.
+- Existing command perception/awareness components, if any.
+- Tactical decision factories and formation behavior components.
+- Current `OrderType`, `OrderData`, `OrderFactory`, and `ProcessOrderSystem`.
+- Debug toggle and current gizmo/debug drawing conventions.
+
+Then implement the smallest generic vertical slice:
+
+1. One Command.
+2. One physical awareness origin.
+3. One observation radius.
+4. Live observed slices.
+5. Debug circle and slice coloring.
+6. No AI decisions yet.
+
+After direct observation works, add captain delivery, stale memory, final aggregation, and AI consumption in separate steps.
+
+---
+
+## 21. Paste-ready continuation instruction
+
+Use this prompt with the project files and repository:
+
+> Continue Battleground2D from the conversation handoff. Treat `Battleground2D_Architecture.md` and `Roadmap.md` as source-of-truth living documents, but apply the newer accepted correction that `SliceState` is objective simulation telemetry while captain reports and `CommandAwareness` represent imperfect knowledge. The immediate target is a generic Command awareness system for both player and AI Commands. Use the existing player Command only as the first debug/test Command. First inspect the current Command, captain-report, slice, order, and behavior code; then propose the smallest single-writer implementation that visualizes the Command radius and directly observed slices without introducing player-only architecture or omniscient AI.
+

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,0 +1,295 @@
+========================
+PHASE 1 — FINALIZE COMBAT SYSTEM
+========================
+
+[x] Fix player only able to attack in original quadrant
+[x] Fix player attacks not setting the right direction
+[x] Fix attacks being delayed
+[x] Replace all combat bools with CombatState / EntityState
+[x] Replace isTakingDamage
+[x] Replace isDefending
+[x] Replace isBlocking
+[x] Replace isAttacking
+[x] Fix AI units taking damage animation looping
+[x] Add block phase system
+[x] Add player block
+[x] Add AI block
+[x] Fix AI blocking regardless of direction
+[x] Setup death phase
+[x] Delete dead entities
+[x] Play death animation
+[x] Fix sprite layer for dead units
+[x] Fix units dying in idle or invalid states
+[x] Make view direction independent of movement direction
+[x] Update AI animation direction logic
+[x] Update Player animation direction logic
+
+
+========================
+PHASE 2 — FORMATIONS & TACTICS (MVP)
+========================
+
+[x] Add FormationComponent
+[x] Add FormationGroupComponent
+[x] Create FormationCombatSystem
+[x] Create FormationMovementSystem
+[x] Implement Hold Position behavior
+[x] Decouple unit commands from formations
+[x] Move formation data ownership to FormationGroup
+[x] Stop per-unit FindTarget before clash
+
+[x] Implement basic Advance command
+[x] Implement straight-line formation advance
+[x] Implement basic attack-move logic
+
+[ ] Implement basic Charge command
+[ ] Require valid target for Charge
+[ ] Add stamina / morale bonuses for Charge
+
+[x] Add formation collision / avoidance
+[x] Fix hard formation bugs (stuck units, NaNs, exit combat issues)
+[x] Ensure formations can move into combat
+[x] Ensure formations fight correctly
+[x] Allow basic break-off / reposition behavior
+
+
+========================
+PHASE 3 — BATTLE LOOP & GLOBAL FRONTLINE (UPDATED)
+========================
+
+[x] FrontlineSlice grid accumulation (heatmap analytics from formation AABBs)
+
+----------------------------------------
+3A — SLICE STATE + FRONTLINE NARRATIVE
+----------------------------------------
+[x] Add persistent SliceState layer (separate from per-frame accumulation)
+[x] Derive per-slice signals: smoothed control + intensity + momentum
+[x] Define SliceState machine (e.g. Empty / Dominated / Contested + Stable / Pressured / Collapsing / Broken)
+[x] Add hysteresis / time-gates to prevent flicker
+[x] Neighbor influence rules (collapse/break spreads pressure to adjacent slices)
+	[x] - review code that sets enemy/ally pressured state, it is only setting eenemy/ally dominant.
+	[x] - review states to make sure it is clear what we want
+[x] Offscreen update mode (cheaper tick + decay for unseen slices) - dont need this yet
+
+----------------------------------------
+3B-0 — CORE DATA FLOW STABILIZATION
+----------------------------------------
+[x] Remove shared multi-writer HasTarget usage
+[x] Create CombatTarget component (entity-only target reference)
+[x] Convert FindTargetSystem to write CombatTarget only
+[x] Convert TargetValidationSystem to validate/clear CombatTarget
+[x] Convert TargetReevaluationSystem to update CombatTarget without movement side effects
+[ ] Remove cached TargetPosition usage from targeting flow
+[x] Create movement goal input components / sources
+	[x] FormationSlotGoal
+	[x] OrderMoveIntent
+	[-] future: PursuitIntent / ChargeIntent
+[x] Create final MoveGoal component
+[x] Implement MoveGoalResolverSystem
+	[x] reads movement goal sources
+	[x] can derive MoveGoal from CombatTarget position when behavior requires pursuit/charge
+	[x] applies priority rules for final movement goal
+[x] Make MoveGoalResolverSystem the only writer of MoveGoal
+[x] Refactor MovementSystem to read MoveGoal only
+[x] Add clean arrive/stop behavior
+	[x] stop radius deadzone
+	[x] no overshoot
+	[x] no jitter near goal
+[x] Add MovementLock (or equivalent) for combat stop/hold behavior
+[x] Combat writes lock/state, not direct movement goals
+[x] Remove HasTarget reads/writes from:
+	[x] ProcessOrderSystem
+	[x] FormationCombatSystem
+	[x] targeting systems
+	[x] movement systems
+[x] Delete HasTarget component once migration is complete
+
+----------------------------------------
+3B — COMMANDS + LOCAL AWARENESS (ANTI-RTS)
+----------------------------------------
+[x] Create Command entity concept (persistent identity: commander + formations owned)
+	- owner of formations
+	- command-level state only
+
+[x] Add dynamic Command label generation from slice context (role + pressure + area)
+	- coarse battlefield identity
+	- no gameplay dependency
+
+[x] Generic Command-local awareness (player Command is the first test case)
+	[x] configurable 14-unit observation radius centered on the physical commander
+	[x] circle-versus-bounds intersection for slices and formations
+	[x] live slice state, formation status, and FormationCaptainReport capture
+	[x] CommandKnownSlice and CommandKnownFormation buffers
+	[x] 10-second frozen stale memory with confidence decay
+	[x] aggregate CommandAwareness summary for future tactical AI
+	[x] global-debug-gated circle, known-slice, and known-formation visualization
+	[x] create FormationCaptainReport (fake captain / informational only)
+		- tied to formation
+		- reads local slice state
+		- reports upward to owned command
+	[x] build CommandAwareness from direct observations + in-range formation reports
+		- no global battlefield truth
+		- player/AI only knows reported local state
+	[ ] future: physical captain + messenger relay
+		- real communication layer
+		- not MVP
+
+[ ] Global awareness: optional coarse “Left/Center/Right” pressure summary (delayed/stale)
+	- aggregated slice pressure
+	- intentionally not exact
+
+[ ] AI Command awareness: formations-local slice reads + reaction delay (no omniscient instant flips)
+	- AI reads CommandAwareness, not raw slices
+	- nearby/local owned info only
+	- delay before reacting
+	- no instant battlefield-wide state changes
+----------------------------------------
+3C — FORMATIONS REGISTER + SLICE-INFLUENCED BEHAVIOR
+----------------------------------------
+[ ] Register formations into slices (area-of-operations window, not just nearest point)
+[ ] Formation behaviors react to SliceState (stable/pressured/collapsing/broken)
+[ ] Player presence modifier (nearby slice stabilizes faster / reduces rout chance)
+
+----------------------------------------
+3D — ORDERS AS INTENT (MVP VERSION)
+----------------------------------------
+[ ] Implement Command-level intents: Hold / Advance / Pull Back / Charge (MVP set)
+[ ] Propagate intents to formations with small delay + optional staggering
+[ ] Formation eligibility checks (e.g. Charge requires target/contact + cohesion; abort if collapsing)
+[ ] Debug/telemetry: visualize current intent + formation compliance (for tuning)
+
+----------------------------------------
+3E — FULL BATTLE LOOP + RUN-THE-LINE
+----------------------------------------
+[ ] Battle state flow: Setup → Running → Victory/Defeat
+[ ] Player can pan across entire battlefield / move between hotspots
+[ ] Ensure visual continuity across slices (no popping or resets when crossing)
+[ ] Minimal HUD: local slice strip + pressure state text/icons (readable while fighting)
+[ ] AFK test: battle evolves meaningfully without player input
+[ ] Run-the-line test: moving across battlefield shows continuous, coherent combat
+========================
+DECOUPLING PASS — OWNERSHIP + PIPELINES
+========================
+
+[ ] Audit `.Complete()` usage
+    [ ] List every `Dependency.Complete()` / `.Complete()` in runtime systems (ignore debug/setup)
+    [ ] Replace each with proper system ordering, ECB usage, or gather/apply job split
+
+[ ] Define authoritative owners / pipelines (single-writer rule)
+    [ ] Combat pipeline owns `CombatState.CurrentState` (only the state machine writes it)
+    [ ] Damage pipeline owns `Health` and `Death/DiedTag`
+    [ ] Motion / Physics pipeline owns `Translation`
+    [ ] Slice pipeline owns `SliceState`
+    [ ] Formation pipeline owns formation structural state (slots, cohesion, group state)
+
+[ ] Ban cross-pipeline writes
+    [ ] Player / AI / Formation systems do NOT write `Translation`
+    [ ] Damage / Attack systems do NOT write `CombatState.CurrentState`
+    [ ] Non-slice systems do NOT write `SliceState`
+    [ ] Non-formation systems do NOT write formation structural state
+
+[ ] Replace cross-system state writes with intents / events
+    [ ] Add `MoveIntent` / `DesiredVelocity` (gameplay → physics)
+    [ ] Add `DamageEvent` or `DamageReaction (timer)` (damage → combat state machine)
+    [ ] Add `CombatIntent` (attack / block / defend) (control / AI → combat state machine)
+    [ ] Ensure events are consumed and cleared by the owning resolve system
+
+[ ] Physics “feel” confirmation
+    [ ] Keep collision correction inside Motion / Physics pipeline (immediate translation correction allowed)
+    [ ] Confirm no late gameplay systems assume post-collision positions unless explicitly ordered
+
+[ ] Phase boundaries and ordering
+    [ ] Document per-frame order:
+        Input / Orders → Targeting → Combat → Damage / Death → Motion / Collision → Animation
+    [ ] Enforce ordering via `[UpdateBefore]`, `[UpdateAfter]`, or custom system groups
+
+
+========================
+PHASE 4 — CO-OP & MESSAGING
+========================
+
+[ ] Add support for 2-player input
+[ ] Share SectorSimulationSystem between players
+[ ] Allow each player to issue formation commands
+[ ] Sync sector and formation updates between players
+
+[ ] Create MessageEntity
+[ ] Add message source player
+[ ] Add message destination player
+[ ] Add message payload (help / retreat / attack)
+[ ] Attach message to current sector
+
+[ ] Implement AI messenger units
+[ ] Spawn messenger on message send
+[ ] Allow messenger to travel sector-to-sector
+[ ] Allow messenger to die or be delayed
+[ ] Deliver UI notification on arrival
+
+[ ] Support player-as-messenger traversal
+
+
+========================
+PHASE 5 — UNIT VARIETY & AI COMMANDER
+========================
+
+[ ] Add unit type enum (infantry, cavalry, archer, etc.)
+[ ] Create AI Commander system
+[ ] Reinforce weak sectors
+[ ] Initiate pushes
+[ ] Retreat collapsing sectors
+[ ] Shift reserves intelligently
+
+[ ] Add archer units
+[ ] Implement basic projectile logic
+[ ] Integrate archers with combat + sector systems
+
+
+========================
+PHASE 6 — PERFORMANCE & SCALING
+========================
+
+[ ] Separate combat systems by responsibility
+[ ] Optimize targeting queries
+[ ] Optimize movement systems
+[ ] Optimize collision systems
+[ ] Introduce group-based physics
+[ ] Add corpse persistence system
+
+[ ] Create UnitData GPU struct
+[ ] Implement initial GPU collision compute shader
+[ ] Create GPUCollisionSystem
+[ ] Integrate GPU collisions with CPU quadrant system
+[ ] Replace CPU collision resolution with GPU results
+[ ] Ensure rendering uses post-GPU positions
+
+[ ] Implement GPU grid broad-phase
+[ ] Implement collision-pair compaction
+[ ] Remove CPU readback bottlenecks
+[ ] Keep full physics loop on GPU
+[ ] Add pressure-wave / organic motion behaviors
+
+
+========================
+PHASE 7 — COMBAT FEEL & POLISH
+========================
+
+[ ] Smooth attack animations
+[ ] Smooth block animations
+[ ] Smooth death animations
+[ ] Fix attack direction & hitboxes
+[ ] Add unit crit chance
+[ ] Add defend-while-moving state
+[ ] Fix units freezing during attack
+
+
+========================
+PHASE 8 — ADVANCED FEATURES & CINEMATIC MOMENTS
+========================
+
+[ ] Add cavalry charge impact physics
+[ ] Improve arrow physics
+[ ] Add environmental / background design
+[ ] Add dynamic rank promotion
+[ ] Add advanced radial formation commands
+[ ] Add commander / captain crit systems
+[ ] Add backwards-walking animations

--- a/battleground2d/Assets/Scripts/ECS_Scripts/EntitySpawner.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/EntitySpawner.cs
@@ -105,7 +105,7 @@ public class EntitySpawner : MonoBehaviour
                 // --- ALLIES ---
                 // Add more rows here whenever you want (e.g., new[] {0f, -8f, -16f})
                 float[] allyRowsY = { -2f/*, -5f */};
-                SpawnAllyPhalanxRows(unitFactory, entitiesToSpawn, allyRowsY);
+                Entity playerCommand = SpawnAllyPhalanxRows(unitFactory, entitiesToSpawn, allyRowsY);
 
                 // --- ENEMIES ---
                 float enemyMoveRange = 50f;
@@ -113,7 +113,10 @@ public class EntitySpawner : MonoBehaviour
                 float[] enemyRowsY = { 10f/*, 15f, 20f, 25f*/ };
                 SpawnEnemyHordeRows(unitFactory, entitiesToSpawn, enemyMoveRange, enemyRowsY);
 
-                unitFactory.SpawnCommander();
+                Entity playerCommander = unitFactory.SpawnCommander();
+                var command = _entityManager.GetComponentData<CommandComponent>(playerCommand);
+                command.AwarenessOrigin = playerCommander;
+                _entityManager.SetComponentData(playerCommand, command);
 
                 hasSpawnedUnits = true;
             }
@@ -121,10 +124,10 @@ public class EntitySpawner : MonoBehaviour
 
     }
 
-    private void SpawnAllyPhalanxRows(UnitFactory factory, int unitsPerFormation, float[] rowsY)
+    private Entity SpawnAllyPhalanxRows(UnitFactory factory, int unitsPerFormation, float[] rowsY)
     {
         // X positions for ally phalanx columns
-        float[] allyXs = { -12f };//, -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f};
+        float[] allyXs = { -12f  -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f};
         Entity cmd = _entityManager.CreateEntity();
         _entityManager.AddComponentData(cmd, new CommandComponent
         {
@@ -142,6 +145,7 @@ public class EntitySpawner : MonoBehaviour
         });
 
         _entityManager.AddBuffer<OwnedFormationGroup>(cmd);
+        AddCommandAwarenessComponents(cmd);
         // Collect first (safe across structural changes)
         var spawnedGroups = new List<Entity>(rowsY.Length * allyXs.Length);
 
@@ -168,11 +172,12 @@ public class EntitySpawner : MonoBehaviour
         var buffer = _entityManager.GetBuffer<OwnedFormationGroup>(cmd);
         for (int i = 0; i < spawnedGroups.Count; i++)
             buffer.Add(new OwnedFormationGroup { Value = spawnedGroups[i] });
+        return cmd;
     }
 
     private void SpawnEnemyHordeRows(UnitFactory factory, int unitsPerFormation, float enemyMoveRange, float[] rowsY)
     {
-        float[] colsX = { -12f };//, -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f };
+        float[] colsX = { -12f -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f };
 
         Entity cmd = _entityManager.CreateEntity();
 
@@ -196,6 +201,7 @@ public class EntitySpawner : MonoBehaviour
         });
 
         _entityManager.AddBuffer<OwnedFormationGroup>(cmd);
+        AddCommandAwarenessComponents(cmd);
 
         var spawnedGroups = new List<Entity>(rowsY.Length * colsX.Length);
 
@@ -224,6 +230,18 @@ public class EntitySpawner : MonoBehaviour
         var buffer = _entityManager.GetBuffer<OwnedFormationGroup>(cmd);
         for (int i = 0; i < spawnedGroups.Count; i++)
             buffer.Add(new OwnedFormationGroup { Value = spawnedGroups[i] });
+    }
+
+    private void AddCommandAwarenessComponents(Entity command)
+    {
+        _entityManager.AddComponentData(command, new CommandAwarenessConfig
+        {
+            ObservationRadius = 14f,
+            MemoryDuration = 10f
+        });
+        _entityManager.AddComponentData(command, new CommandAwareness());
+        _entityManager.AddBuffer<CommandKnownSlice>(command);
+        _entityManager.AddBuffer<CommandKnownFormation>(command);
     }
 
 

--- a/battleground2d/Assets/Scripts/ECS_Scripts/EntitySpawner.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/EntitySpawner.cs
@@ -127,7 +127,7 @@ public class EntitySpawner : MonoBehaviour
     private Entity SpawnAllyPhalanxRows(UnitFactory factory, int unitsPerFormation, float[] rowsY)
     {
         // X positions for ally phalanx columns
-        float[] allyXs = { -12f  -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f};
+        float[] allyXs = { -12f,  -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f};
         Entity cmd = _entityManager.CreateEntity();
         _entityManager.AddComponentData(cmd, new CommandComponent
         {
@@ -177,7 +177,7 @@ public class EntitySpawner : MonoBehaviour
 
     private void SpawnEnemyHordeRows(UnitFactory factory, int unitsPerFormation, float enemyMoveRange, float[] rowsY)
     {
-        float[] colsX = { -12f -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f };
+        float[] colsX = { -12f, -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f };
 
         Entity cmd = _entityManager.CreateEntity();
 

--- a/battleground2d/Assets/Scripts/ECS_Scripts/Systems/CommandAwarenessSystem.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/Systems/CommandAwarenessSystem.cs
@@ -1,0 +1,322 @@
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using static EntitySpawner;
+
+public enum AwarenessSource : byte
+{
+    DirectObservation,
+    Memory
+}
+
+public struct CommandAwarenessConfig : IComponentData
+{
+    public float ObservationRadius;
+    public float MemoryDuration;
+}
+
+public struct CommandKnownSlice : IBufferElementData
+{
+    public int SliceKey;
+    public float Control;
+    public float Intensity;
+    public float Momentum;
+    public SliceTacticalState State;
+    public double LastObservedTime;
+    public float Confidence;
+    public AwarenessSource Source;
+}
+
+public struct CommandKnownFormation : IBufferElementData
+{
+    public Entity Formation;
+    public UnitType Faction;
+    public float2 BoundsMin;
+    public float2 BoundsMax;
+    public FormationStatusEnum Status;
+    public FormationCaptainState CaptainState;
+    public float CaptainControl;
+    public float CaptainIntensity;
+    public float CaptainMomentum;
+    public int AliveUnitCount;
+    public byte HasCaptainReport;
+    public double LastObservedTime;
+    public float Confidence;
+    public AwarenessSource Source;
+}
+
+public struct CommandAwareness : IComponentData
+{
+    public uint IntelVersion;
+    public float Control;
+    public float Intensity;
+    public float Momentum;
+    public float Confidence;
+    public CommandPressureState Pressure;
+    public int KnownSliceCount;
+    public int FriendlyFormationCount;
+    public int EnemyFormationCount;
+    public double LastUpdatedTime;
+}
+
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+[UpdateAfter(typeof(FormationCaptainReportSystem))]
+public partial class CommandAwarenessSystem : SystemBase
+{
+    private static readonly float2 SliceOrigin = new float2(-32f, -16f);
+    private EntityQuery _commandQuery;
+    private EntityQuery _formationQuery;
+
+    protected override void OnCreate()
+    {
+        _commandQuery = GetEntityQuery(
+            ComponentType.ReadOnly<CommandComponent>(),
+            ComponentType.ReadOnly<CommandAwarenessConfig>(),
+            ComponentType.ReadWrite<CommandAwareness>(),
+            ComponentType.ReadWrite<CommandPerception>(),
+            ComponentType.ReadWrite<CommandKnownSlice>(),
+            ComponentType.ReadWrite<CommandKnownFormation>());
+
+        _formationQuery = GetEntityQuery(ComponentType.ReadOnly<FormationGroupComponent>());
+    }
+
+    protected override void OnUpdate()
+    {
+        if (!SliceGridSystem.SliceStateMap.IsCreated)
+            return;
+
+        Dependency.Complete();
+
+        double now = Time.ElapsedTime;
+        var translations = GetComponentDataFromEntity<Translation>(true);
+        var captains = GetComponentDataFromEntity<FormationCaptainComponent>(true);
+
+        var commandEntities = _commandQuery.ToEntityArray(Allocator.TempJob);
+        var commands = _commandQuery.ToComponentDataArray<CommandComponent>(Allocator.TempJob);
+        var configs = _commandQuery.ToComponentDataArray<CommandAwarenessConfig>(Allocator.TempJob);
+        var formationEntities = _formationQuery.ToEntityArray(Allocator.TempJob);
+        var formations = _formationQuery.ToComponentDataArray<FormationGroupComponent>(Allocator.TempJob);
+        var sliceStates = SliceGridSystem.SliceStateMap.GetKeyValueArrays(Allocator.TempJob);
+
+        for (int commandIndex = 0; commandIndex < commandEntities.Length; commandIndex++)
+        {
+            Entity commandEntity = commandEntities[commandIndex];
+            CommandComponent command = commands[commandIndex];
+            CommandAwarenessConfig config = configs[commandIndex];
+
+            if (command.AwarenessOrigin == Entity.Null || !translations.HasComponent(command.AwarenessOrigin))
+                continue;
+
+            float2 origin = translations[command.AwarenessOrigin].Value.xy;
+            float radius = math.max(0f, config.ObservationRadius);
+            float memoryDuration = math.max(0.01f, config.MemoryDuration);
+
+            DynamicBuffer<CommandKnownSlice> knownSlices = EntityManager.GetBuffer<CommandKnownSlice>(commandEntity);
+            DynamicBuffer<CommandKnownFormation> knownFormations = EntityManager.GetBuffer<CommandKnownFormation>(commandEntity);
+
+            AgeSliceMemory(ref knownSlices, now, memoryDuration);
+            AgeFormationMemory(ref knownFormations, now, memoryDuration);
+
+            for (int i = 0; i < sliceStates.Keys.Length; i++)
+            {
+                int key = sliceStates.Keys[i];
+                int2 cell = SliceGridUtil.DecodeKey(key);
+                SliceGridUtil.CellBounds(cell, SliceOrigin, out float2 min, out float2 max);
+                if (!CircleIntersectsAabb(origin, radius, min, max))
+                    continue;
+
+                SliceStateData state = sliceStates.Values[i];
+                UpsertSlice(ref knownSlices, new CommandKnownSlice
+                {
+                    SliceKey = key,
+                    Control = state.SmoothedControl,
+                    Intensity = state.SmoothedIntensity,
+                    Momentum = state.Momentum,
+                    State = state.State,
+                    LastObservedTime = now,
+                    Confidence = 1f,
+                    Source = AwarenessSource.DirectObservation
+                });
+            }
+
+            for (int i = 0; i < formationEntities.Length; i++)
+            {
+                FormationGroupComponent group = formations[i];
+                float2 min = group.BoundsMin;
+                float2 max = group.BoundsMax;
+                if (max.x < min.x || max.y < min.y)
+                    min = max = group.AnchorPosition;
+
+                if (!CircleIntersectsAabb(origin, radius, min, max))
+                    continue;
+
+                Entity formationEntity = formationEntities[i];
+                bool hasCaptain = captains.HasComponent(formationEntity);
+                FormationCaptainComponent captain = hasCaptain
+                    ? captains[formationEntity]
+                    : default;
+
+                UpsertFormation(ref knownFormations, new CommandKnownFormation
+                {
+                    Formation = formationEntity,
+                    Faction = group.UnitType,
+                    BoundsMin = min,
+                    BoundsMax = max,
+                    Status = group.FormationGroupStatus,
+                    CaptainState = captain.State,
+                    CaptainControl = captain.Control,
+                    CaptainIntensity = captain.Intensity,
+                    CaptainMomentum = captain.Momentum,
+                    AliveUnitCount = group.AliveUnitCount,
+                    HasCaptainReport = (byte)(hasCaptain ? 1 : 0),
+                    LastObservedTime = now,
+                    Confidence = 1f,
+                    Source = AwarenessSource.DirectObservation
+                });
+            }
+
+            CommandAwareness awareness = EntityManager.GetComponentData<CommandAwareness>(commandEntity);
+            BuildSummary(ref awareness, knownSlices, knownFormations, command.FactionType, now);
+            EntityManager.SetComponentData(commandEntity, awareness);
+
+            // Keep the existing consumer-facing component synchronized during migration.
+            CommandPerception perception = EntityManager.GetComponentData<CommandPerception>(commandEntity);
+            perception.IntelVersion = awareness.IntelVersion;
+            perception.PrevControl = perception.Control;
+            perception.Control = awareness.Control;
+            perception.Intensity01 = awareness.Intensity;
+            perception.Momentum = awareness.Momentum;
+            perception.Pressure = awareness.Pressure;
+            EntityManager.SetComponentData(commandEntity, perception);
+        }
+
+        sliceStates.Dispose();
+        formations.Dispose();
+        formationEntities.Dispose();
+        configs.Dispose();
+        commands.Dispose();
+        commandEntities.Dispose();
+    }
+
+    private static void AgeSliceMemory(ref DynamicBuffer<CommandKnownSlice> buffer, double now, float duration)
+    {
+        for (int i = buffer.Length - 1; i >= 0; i--)
+        {
+            CommandKnownSlice entry = buffer[i];
+            float age = (float)(now - entry.LastObservedTime);
+            if (age >= duration)
+            {
+                buffer.RemoveAt(i);
+                continue;
+            }
+
+            entry.Source = AwarenessSource.Memory;
+            entry.Confidence = math.saturate(1f - age / duration);
+            buffer[i] = entry;
+        }
+    }
+
+    private static void AgeFormationMemory(ref DynamicBuffer<CommandKnownFormation> buffer, double now, float duration)
+    {
+        for (int i = buffer.Length - 1; i >= 0; i--)
+        {
+            CommandKnownFormation entry = buffer[i];
+            float age = (float)(now - entry.LastObservedTime);
+            if (age >= duration)
+            {
+                buffer.RemoveAt(i);
+                continue;
+            }
+
+            entry.Source = AwarenessSource.Memory;
+            entry.Confidence = math.saturate(1f - age / duration);
+            buffer[i] = entry;
+        }
+    }
+
+    private static void UpsertSlice(ref DynamicBuffer<CommandKnownSlice> buffer, CommandKnownSlice value)
+    {
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            if (buffer[i].SliceKey != value.SliceKey)
+                continue;
+            buffer[i] = value;
+            return;
+        }
+        buffer.Add(value);
+    }
+
+    private static void UpsertFormation(ref DynamicBuffer<CommandKnownFormation> buffer, CommandKnownFormation value)
+    {
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            if (buffer[i].Formation != value.Formation)
+                continue;
+            buffer[i] = value;
+            return;
+        }
+        buffer.Add(value);
+    }
+
+    private static void BuildSummary(
+        ref CommandAwareness awareness,
+        DynamicBuffer<CommandKnownSlice> slices,
+        DynamicBuffer<CommandKnownFormation> formations,
+        UnitType faction,
+        double now)
+    {
+        float weightedControl = 0f;
+        float weightedMomentum = 0f;
+        float weightSum = 0f;
+        float maxIntensity = 0f;
+        float confidenceSum = 0f;
+
+        for (int i = 0; i < slices.Length; i++)
+        {
+            CommandKnownSlice slice = slices[i];
+            float commandControl = faction == UnitType.Ally ? slice.Control : -slice.Control;
+            float commandMomentum = faction == UnitType.Ally ? slice.Momentum : -slice.Momentum;
+            float weight = math.max(0.001f, slice.Intensity) * slice.Confidence;
+            weightedControl += commandControl * weight;
+            weightedMomentum += commandMomentum * weight;
+            weightSum += weight;
+            maxIntensity = math.max(maxIntensity, slice.Intensity * slice.Confidence);
+            confidenceSum += slice.Confidence;
+        }
+
+        int friendly = 0;
+        int enemy = 0;
+        for (int i = 0; i < formations.Length; i++)
+        {
+            if (formations[i].Faction == faction) friendly++;
+            else enemy++;
+        }
+
+        awareness.Control = weightSum > 0f ? weightedControl / weightSum : 0f;
+        awareness.Momentum = weightSum > 0f ? weightedMomentum / weightSum : 0f;
+        awareness.Intensity = maxIntensity;
+        awareness.Confidence = slices.Length > 0 ? confidenceSum / slices.Length : 0f;
+        awareness.KnownSliceCount = slices.Length;
+        awareness.FriendlyFormationCount = friendly;
+        awareness.EnemyFormationCount = enemy;
+        awareness.Pressure = ClassifyPressure(awareness.Control, awareness.Intensity, awareness.Momentum);
+        awareness.IntelVersion++;
+        awareness.LastUpdatedTime = now;
+    }
+
+    private static CommandPressureState ClassifyPressure(float control, float intensity, float momentum)
+    {
+        if (intensity < 0.05f) return CommandPressureState.Stable;
+        if (control < -0.50f && intensity > 0.25f && momentum < 0f) return CommandPressureState.Broken;
+        if (control < -0.25f && intensity > 0.20f && momentum < 0f) return CommandPressureState.Collapsing;
+        if (control < -0.10f && intensity > 0.15f) return CommandPressureState.Pressured;
+        return CommandPressureState.Stable;
+    }
+
+    public static bool CircleIntersectsAabb(float2 center, float radius, float2 min, float2 max)
+    {
+        float2 closest = math.clamp(center, min, max);
+        return math.lengthsq(closest - center) <= radius * radius;
+    }
+}

--- a/battleground2d/Assets/Scripts/ECS_Scripts/Systems/CommandAwarenessSystem.cs.meta
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/Systems/CommandAwarenessSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83a8674563f14f63a2d3d4f81acbd1f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/battleground2d/Assets/Scripts/ECS_Scripts/Systems/SliceAwarenessSystem.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/Systems/SliceAwarenessSystem.cs
@@ -10,6 +10,7 @@ using static UnityEngine.EventSystems.EventTrigger;
 
 [UpdateInGroup(typeof(SimulationSystemGroup))]
 [UpdateAfter(typeof(SliceGridSystem))]
+[DisableAutoCreation]
 public partial class SliceAwarenessSystem : SystemBase
 {
     protected override void OnCreate()
@@ -225,6 +226,7 @@ public struct CommandComponent : IComponentData
 {
     public UnitType FactionType;
     public int CommandID;          // Left / Center / Right (or enum later)
+    public Entity AwarenessOrigin; // Physical commander used for local observation
 }
 public struct OwnedFormationGroup : IBufferElementData
 {

--- a/battleground2d/Assets/Scripts/FormationDebugDrawer.cs
+++ b/battleground2d/Assets/Scripts/FormationDebugDrawer.cs
@@ -140,6 +140,89 @@ public class FormationDebugDrawer : MonoBehaviour
 
         captains.Dispose();
         groups.Dispose();
+
+        DrawCommandAwareness(em, style);
+    }
+
+    private static void DrawCommandAwareness(EntityManager em, GUIStyle labelStyle)
+    {
+        var query = em.CreateEntityQuery(
+            ComponentType.ReadOnly<CommandComponent>(),
+            ComponentType.ReadOnly<CommandAwarenessConfig>(),
+            ComponentType.ReadOnly<CommandAwareness>(),
+            ComponentType.ReadOnly<CommandKnownSlice>(),
+            ComponentType.ReadOnly<CommandKnownFormation>());
+
+        var commandEntities = query.ToEntityArray(Unity.Collections.Allocator.Temp);
+        var commands = query.ToComponentDataArray<CommandComponent>(Unity.Collections.Allocator.Temp);
+        var configs = query.ToComponentDataArray<CommandAwarenessConfig>(Unity.Collections.Allocator.Temp);
+
+        for (int i = 0; i < commandEntities.Length; i++)
+        {
+            CommandComponent command = commands[i];
+            if (command.AwarenessOrigin == Entity.Null || !em.HasComponent<Translation>(command.AwarenessOrigin))
+                continue;
+
+            float2 origin = em.GetComponentData<Translation>(command.AwarenessOrigin).Value.xy;
+            Vector3 origin3 = new Vector3(origin.x, origin.y, 0f);
+
+            Handles.color = Color.cyan;
+            Handles.DrawWireDisc(origin3, Vector3.forward, configs[i].ObservationRadius);
+
+            DynamicBuffer<CommandKnownSlice> slices = em.GetBuffer<CommandKnownSlice>(commandEntities[i]);
+            for (int sliceIndex = 0; sliceIndex < slices.Length; sliceIndex++)
+            {
+                CommandKnownSlice slice = slices[sliceIndex];
+                int2 cell = SliceGridUtil.DecodeKey(slice.SliceKey);
+                SliceGridUtil.CellBounds(cell, new float2(-32f, -16f), out float2 min, out float2 max);
+                Color color = slice.Source == AwarenessSource.DirectObservation
+                    ? new Color(0f, 1f, 1f, 0.9f)
+                    : new Color(0.4f, 0.7f, 0.7f, math.max(0.15f, slice.Confidence));
+                DrawAabb(min, max, color);
+            }
+
+            DynamicBuffer<CommandKnownFormation> formations = em.GetBuffer<CommandKnownFormation>(commandEntities[i]);
+            for (int formationIndex = 0; formationIndex < formations.Length; formationIndex++)
+            {
+                CommandKnownFormation formation = formations[formationIndex];
+                Color color = formation.Faction == command.FactionType ? Color.green : Color.red;
+                if (formation.Source == AwarenessSource.Memory)
+                    color = new Color(color.r, color.g, color.b, math.max(0.15f, formation.Confidence));
+
+                DrawAabb(formation.BoundsMin, formation.BoundsMax, color);
+                float2 formationCenter = (formation.BoundsMin + formation.BoundsMax) * 0.5f;
+                Gizmos.color = color;
+                Gizmos.DrawLine(origin3, new Vector3(formationCenter.x, formationCenter.y, 0f));
+            }
+
+            CommandAwareness awareness = em.GetComponentData<CommandAwareness>(commandEntities[i]);
+            labelStyle.normal.textColor = Color.cyan;
+            Handles.Label(
+                origin3 + Vector3.up,
+                $"Awareness R:{configs[i].ObservationRadius:F0}\n" +
+                $"Slices:{awareness.KnownSliceCount} Friendly:{awareness.FriendlyFormationCount} Enemy:{awareness.EnemyFormationCount}\n" +
+                $"Pressure:{awareness.Pressure} C:{awareness.Control:F2} I:{awareness.Intensity:F2}",
+                labelStyle);
+        }
+
+        Handles.color = Color.white;
+        configs.Dispose();
+        commands.Dispose();
+        commandEntities.Dispose();
+    }
+
+    private static void DrawAabb(float2 min, float2 max, Color color)
+    {
+        Vector3 bottomLeft = new Vector3(min.x, min.y, 0f);
+        Vector3 bottomRight = new Vector3(max.x, min.y, 0f);
+        Vector3 topRight = new Vector3(max.x, max.y, 0f);
+        Vector3 topLeft = new Vector3(min.x, max.y, 0f);
+
+        Gizmos.color = color;
+        Gizmos.DrawLine(bottomLeft, bottomRight);
+        Gizmos.DrawLine(bottomRight, topRight);
+        Gizmos.DrawLine(topRight, topLeft);
+        Gizmos.DrawLine(topLeft, bottomLeft);
     }
 }
 #endif

--- a/battleground2d/Assets/Scripts/UnitFactory.cs
+++ b/battleground2d/Assets/Scripts/UnitFactory.cs
@@ -107,11 +107,12 @@ public class UnitFactory
     }
 
     //TODO: add bool for setting AI commander component
-    public void SpawnCommander()
+    public Entity SpawnCommander()
     {
         var commander = CreateUnitBase(new float2(4, 0), UnitType.Ally, 7, Direction.Right, 100000f);
         entityManager.AddComponent<CommanderComponent>(commander);
         entityManager.SetComponentData(commander, new CommanderComponent { isPlayerControlled = true });
+        return commander;
     }
 
 


### PR DESCRIPTION
﻿## What changed

- Link the abstract Command entity to its physical commander as the awareness origin.
- Add a configurable 14-unit observation radius using circle-versus-AABB intersection.
- Capture nearby slice telemetry, formation status, and formation captain information.
- Store detailed CommandKnownSlice and CommandKnownFormation knowledge.
- Add 10-second frozen memory with confidence decay for information leaving observation range.
- Aggregate known information into CommandAwareness for future tactical AI.
- Draw the awareness boundary, known slices, known formations, and summary through the existing global debug toggle.
- Disable the superseded partial SliceAwarenessSystem while keeping FormationCaptainReportSystem active.
- Add and update the architecture, roadmap, and conversation handoff documents.

## Why

Commands need a local, imperfect knowledge boundary so player and future AI decisions do not consume omniscient battlefield state. The new data model supports both high-level tactical summaries and detailed planning while preserving stale information realistically.

## Validation

- Confirmed the awareness circle and debug information in Unity play mode.
- Verified compatibility against the cached Unity Entities 0.16.0-preview.21 API.
- Ran git diff --check; source changes passed, with one harmless trailing blank line reported in the handoff document.
- Full batch compilation was unavailable because the installed Unity editor reports an invalid machine-bound license.

## Review notes

This is a draft so the observation radius, debug presentation, memory behavior, and awareness summary can be tuned before merge.
