### PR TITLE
Refactor command awareness to entity-based translation

### DIFF
--- a/battleground2d/Assets/Scripts/ECS_Scripts/EntitySpawner.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/EntitySpawner.cs
@@ -105,18 +105,16 @@ public class EntitySpawner : MonoBehaviour
                 // --- ALLIES ---
                 // Add more rows here whenever you want (e.g., new[] {0f, -8f, -16f})
                 float[] allyRowsY = { -2f/*, -5f */};
-                Entity playerCommand = SpawnAllyPhalanxRows(unitFactory, entitiesToSpawn, allyRowsY);
+                Entity playerCommander = unitFactory.SpawnCommander(UnitType.Ally, new float2(4, 0), 100000f, true);
+                _entityManager.AddComponent<PlayerInputComponent>(playerCommander);
+                SpawnAllyPhalanxRows(unitFactory, playerCommander, entitiesToSpawn, allyRowsY);
 
                 // --- ENEMIES ---
                 float enemyMoveRange = 50f;
                 // Add more rows by just appending values
                 float[] enemyRowsY = { 10f/*, 15f, 20f, 25f*/ };
-                SpawnEnemyHordeRows(unitFactory, entitiesToSpawn, enemyMoveRange, enemyRowsY);
-
-                Entity playerCommander = unitFactory.SpawnCommander();
-                var command = _entityManager.GetComponentData<CommandComponent>(playerCommand);
-                command.AwarenessOrigin = playerCommander;
-                _entityManager.SetComponentData(playerCommand, command);
+                Entity enemyCommander = unitFactory.SpawnCommander(UnitType.Enemy, new float2(4, 2), 100000f, false);
+                SpawnEnemyHordeRows(unitFactory, enemyCommander, entitiesToSpawn, enemyMoveRange, enemyRowsY);
 
                 hasSpawnedUnits = true;
             }
@@ -124,17 +122,16 @@ public class EntitySpawner : MonoBehaviour
 
     }
 
-    private Entity SpawnAllyPhalanxRows(UnitFactory factory, int unitsPerFormation, float[] rowsY)
+    private void SpawnAllyPhalanxRows(UnitFactory factory, Entity commanderEntity, int unitsPerFormation, float[] rowsY)
     {
         // X positions for ally phalanx columns
         float[] allyXs = { -12f,  -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f};
-        Entity cmd = _entityManager.CreateEntity();
-        _entityManager.AddComponentData(cmd, new CommandComponent
+        _entityManager.AddComponentData(commanderEntity, new CommandComponent
         {
             FactionType = UnitType.Ally,
             CommandID = 0 // Left
         });
-        _entityManager.AddComponentData(cmd, new CommandPerception
+        _entityManager.AddComponentData(commanderEntity, new CommandPerception
         {
             IntelVersion = 0,
             Control = 0f,
@@ -144,8 +141,8 @@ public class EntitySpawner : MonoBehaviour
             Pressure = CommandPressureState.Stable
         });
 
-        _entityManager.AddBuffer<OwnedFormationGroup>(cmd);
-        AddCommandAwarenessComponents(cmd);
+        _entityManager.AddBuffer<OwnedFormationGroup>(commanderEntity);
+        AddCommandAwarenessComponents(commanderEntity);
         // Collect first (safe across structural changes)
         var spawnedGroups = new List<Entity>(rowsY.Length * allyXs.Length);
 
@@ -169,28 +166,22 @@ public class EntitySpawner : MonoBehaviour
         }
 
         // Now get the buffer AFTER spawns (no structural changes after this point)
-        var buffer = _entityManager.GetBuffer<OwnedFormationGroup>(cmd);
+        var buffer = _entityManager.GetBuffer<OwnedFormationGroup>(commanderEntity);
         for (int i = 0; i < spawnedGroups.Count; i++)
             buffer.Add(new OwnedFormationGroup { Value = spawnedGroups[i] });
-        return cmd;
     }
 
-    private void SpawnEnemyHordeRows(UnitFactory factory, int unitsPerFormation, float enemyMoveRange, float[] rowsY)
+    private void SpawnEnemyHordeRows(UnitFactory factory, Entity commanderEntity, int unitsPerFormation, float enemyMoveRange, float[] rowsY)
     {
         float[] colsX = { -12f, -6f, 0f, 6f, 12f, 18f, 24f, 30f, 36f, 42f, 48f, 54f, 60f, 66f };
 
-        Entity cmd = _entityManager.CreateEntity();
-
-        _entityManager.AddComponentData(cmd, new CommandComponent
+        _entityManager.AddComponentData(commanderEntity, new CommandComponent
         {
             FactionType = UnitType.Enemy,
             CommandID = 0
-        });        _entityManager.AddComponentData(cmd, new Translation
-        {
-            Value = new float3(0, 0, 0)
         });
 
-        _entityManager.AddComponentData(cmd, new CommandPerception
+        _entityManager.AddComponentData(commanderEntity, new CommandPerception
         {
             IntelVersion = 0,
             Control = 0f,
@@ -200,8 +191,8 @@ public class EntitySpawner : MonoBehaviour
             Pressure = CommandPressureState.Stable
         });
 
-        _entityManager.AddBuffer<OwnedFormationGroup>(cmd);
-        AddCommandAwarenessComponents(cmd);
+        _entityManager.AddBuffer<OwnedFormationGroup>(commanderEntity);
+        AddCommandAwarenessComponents(commanderEntity);
 
         var spawnedGroups = new List<Entity>(rowsY.Length * colsX.Length);
 
@@ -227,7 +218,7 @@ public class EntitySpawner : MonoBehaviour
             }
         }
 
-        var buffer = _entityManager.GetBuffer<OwnedFormationGroup>(cmd);
+        var buffer = _entityManager.GetBuffer<OwnedFormationGroup>(commanderEntity);
         for (int i = 0; i < spawnedGroups.Count; i++)
             buffer.Add(new OwnedFormationGroup { Value = spawnedGroups[i] });
     }

--- a/battleground2d/Assets/Scripts/ECS_Scripts/Systems/CommandAwarenessSystem.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/Systems/CommandAwarenessSystem.cs
@@ -72,6 +72,7 @@ public partial class CommandAwarenessSystem : SystemBase
     {
         _commandQuery = GetEntityQuery(
             ComponentType.ReadOnly<CommandComponent>(),
+            ComponentType.ReadOnly<Translation>(),
             ComponentType.ReadOnly<CommandAwarenessConfig>(),
             ComponentType.ReadWrite<CommandAwareness>(),
             ComponentType.ReadWrite<CommandPerception>(),
@@ -93,7 +94,6 @@ public partial class CommandAwarenessSystem : SystemBase
         var captains = GetComponentDataFromEntity<FormationCaptainComponent>(true);
 
         var commandEntities = _commandQuery.ToEntityArray(Allocator.TempJob);
-        var commands = _commandQuery.ToComponentDataArray<CommandComponent>(Allocator.TempJob);
         var configs = _commandQuery.ToComponentDataArray<CommandAwarenessConfig>(Allocator.TempJob);
         var formationEntities = _formationQuery.ToEntityArray(Allocator.TempJob);
         var formations = _formationQuery.ToComponentDataArray<FormationGroupComponent>(Allocator.TempJob);
@@ -102,13 +102,10 @@ public partial class CommandAwarenessSystem : SystemBase
         for (int commandIndex = 0; commandIndex < commandEntities.Length; commandIndex++)
         {
             Entity commandEntity = commandEntities[commandIndex];
-            CommandComponent command = commands[commandIndex];
+            CommandComponent command = EntityManager.GetComponentData<CommandComponent>(commandEntity);
             CommandAwarenessConfig config = configs[commandIndex];
 
-            if (command.AwarenessOrigin == Entity.Null || !translations.HasComponent(command.AwarenessOrigin))
-                continue;
-
-            float2 origin = translations[command.AwarenessOrigin].Value.xy;
+            float2 origin = translations[commandEntity].Value.xy;
             float radius = math.max(0f, config.ObservationRadius);
             float memoryDuration = math.max(0.01f, config.MemoryDuration);
 
@@ -195,7 +192,6 @@ public partial class CommandAwarenessSystem : SystemBase
         formations.Dispose();
         formationEntities.Dispose();
         configs.Dispose();
-        commands.Dispose();
         commandEntities.Dispose();
     }
 

--- a/battleground2d/Assets/Scripts/ECS_Scripts/Systems/PlayerControlSystem.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/Systems/PlayerControlSystem.cs
@@ -41,7 +41,7 @@ public class PlayerControlSystem : SystemBase
 
 
         // Check if we have a commander
-        if (!HasSingleton<CommanderComponent>())
+        if (!HasSingleton<PlayerInputComponent>())
             return;
 
         float moveX = 0f;
@@ -137,8 +137,22 @@ public class PlayerControlSystem : SystemBase
 
         //var ecb = _ecbSystem.CreateCommandBuffer();
         var parallelEcb = _ecbSystem.CreateCommandBuffer().AsParallelWriter();
-        var commanderEntity = GetSingletonEntity<CommanderComponent>();
-        var commanderTranslation = GetComponent<Translation>(commanderEntity);
+        Translation commanderTranslation = new Translation();
+
+        Entities
+            .WithName("GetPlayerCommanderPosition")
+            .WithAll<PlayerInputComponent>()
+            .ForEach((
+                in CommanderComponent commander,
+                in Translation translation) =>
+            {
+                if (!commander.isPlayerControlled)
+                    return;
+
+                commanderTranslation = translation;
+            })
+            .WithoutBurst()
+            .Run();
         // Number keys 1-9
         for (int key = (int)KeyCode.Alpha1; key <= (int)KeyCode.Alpha9; key++)
         {

--- a/battleground2d/Assets/Scripts/ECS_Scripts/Systems/SliceAwarenessSystem.cs
+++ b/battleground2d/Assets/Scripts/ECS_Scripts/Systems/SliceAwarenessSystem.cs
@@ -226,7 +226,6 @@ public struct CommandComponent : IComponentData
 {
     public UnitType FactionType;
     public int CommandID;          // Left / Center / Right (or enum later)
-    public Entity AwarenessOrigin; // Physical commander used for local observation
 }
 public struct OwnedFormationGroup : IBufferElementData
 {

--- a/battleground2d/Assets/Scripts/FormationDebugDrawer.cs
+++ b/battleground2d/Assets/Scripts/FormationDebugDrawer.cs
@@ -148,22 +148,19 @@ public class FormationDebugDrawer : MonoBehaviour
     {
         var query = em.CreateEntityQuery(
             ComponentType.ReadOnly<CommandComponent>(),
+            ComponentType.ReadOnly<Translation>(),
             ComponentType.ReadOnly<CommandAwarenessConfig>(),
             ComponentType.ReadOnly<CommandAwareness>(),
             ComponentType.ReadOnly<CommandKnownSlice>(),
             ComponentType.ReadOnly<CommandKnownFormation>());
 
         var commandEntities = query.ToEntityArray(Unity.Collections.Allocator.Temp);
-        var commands = query.ToComponentDataArray<CommandComponent>(Unity.Collections.Allocator.Temp);
         var configs = query.ToComponentDataArray<CommandAwarenessConfig>(Unity.Collections.Allocator.Temp);
 
         for (int i = 0; i < commandEntities.Length; i++)
         {
-            CommandComponent command = commands[i];
-            if (command.AwarenessOrigin == Entity.Null || !em.HasComponent<Translation>(command.AwarenessOrigin))
-                continue;
-
-            float2 origin = em.GetComponentData<Translation>(command.AwarenessOrigin).Value.xy;
+            CommandComponent command = em.GetComponentData<CommandComponent>(commandEntities[i]);
+            float2 origin = em.GetComponentData<Translation>(commandEntities[i]).Value.xy;
             Vector3 origin3 = new Vector3(origin.x, origin.y, 0f);
 
             Handles.color = Color.cyan;
@@ -207,7 +204,6 @@ public class FormationDebugDrawer : MonoBehaviour
 
         Handles.color = Color.white;
         configs.Dispose();
-        commands.Dispose();
         commandEntities.Dispose();
     }
 

--- a/battleground2d/Assets/Scripts/UnitFactory.cs
+++ b/battleground2d/Assets/Scripts/UnitFactory.cs
@@ -107,11 +107,11 @@ public class UnitFactory
     }
 
     //TODO: add bool for setting AI commander component
-    public Entity SpawnCommander()
+    public Entity SpawnCommander(UnitType unitType, float2 spawnLocation, float health, bool isPlayerControlled)
     {
-        var commander = CreateUnitBase(new float2(4, 0), UnitType.Ally, 7, Direction.Right, 100000f);
+        var commander = CreateUnitBase(spawnLocation, unitType, 7, Direction.Right, health);
         entityManager.AddComponent<CommanderComponent>(commander);
-        entityManager.SetComponentData(commander, new CommanderComponent { isPlayerControlled = true });
+        entityManager.SetComponentData(commander, new CommanderComponent { isPlayerControlled = isPlayerControlled });
         return commander;
     }
 
@@ -275,7 +275,7 @@ public class UnitArchetypeFactory
     private EntityArchetype CreateCommanderArchetype()
     {
         return entityManager.CreateArchetype(
-            typeof(CommanderComponent), typeof(PlayerInputComponent),
+            typeof(CommanderComponent),
             typeof(PositionComponent), typeof(Translation), typeof(MovementSpeedComponent),
             typeof(HealthComponent), typeof(AttackComponent), typeof(AttackCooldownComponent),
             typeof(CombatState), typeof(AnimationComponent), typeof(Unit), typeof(QuadrantEntity),


### PR DESCRIPTION
Spawn commanders as proper entities and use the command entity's Translation as the awareness origin. EntitySpawner now creates player/enemy commander entities (player gets PlayerInputComponent) and passes commander Entity into spawn helpers; Spawn* methods no longer return an Entity. CommandComponent's AwarenessOrigin field was removed. CommandAwarenessSystem and FormationDebugDrawer now require/read Translation and use the command entity's Translation; removed unused component-array allocations. PlayerControlSystem checks PlayerInputComponent and reads the player commander Translation via an Entities query. UnitFactory.SpawnCommander signature expanded to configure type, location, health, and player control; commander archetype no longer includes PlayerInputComponent by default.